### PR TITLE
rephrase german translation of the disclaimer in strings.json

### DIFF
--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -56,6 +56,6 @@
   "disclaimer": {
     "en": "Originally made for the purposes of the debaters from ZSK Poznań as well as various Polish debate organisations. Available freely.",
     "pl": "Oryginalnie stworzone na potrzeby debatantów ZSK Poznań oraz różnych polskich organizacji debatanckich. Dostępne publicznie.",
-    "de": "Originell herstellt um die Notwendigkeiten der Posener und Polnisher Debattierer zu befriedigen. Öffentlich zugängliche."
+    "de": "Ursprünglich hergestellt zum Zweck der Debatierer von ZSK Poznań und anderer polnisher Debattenorganisationen. Öffentlich zugänglich."
   }
 }


### PR DESCRIPTION
The new translation of the disclaimer was consulted with a German native speaker. It conveys the original meaning way better and is phrased more naturally.