### PR TITLE
add motions from oxford debate tournaments on social and legal topics

### DIFF
--- a/src/data/motion.json
+++ b/src/data/motion.json
@@ -43,6 +43,216 @@
   },
   {
     "lang": "pl",
+    "motion": "W Polsce należy wprowadzić test preferencji politycznych",
+    "adinfo": "Na potrzeby debaty test preferencji politycznych stanowi test składający się z pytań dotyczących określonych polityk, poglądów oraz wartości. Po wypełnieniu testu, system ustala do którego z kandydatów głosujący ma najbardziej zbliżone odpowiedzi i oddaje na niego automatycznie głos.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Państwo tworząc regulacje hazardowe  powinno dążyć do całkowitego zakazu  (zwiększenie kar finansowych dla organizatorów, zdecydowane ograniczenia dostępności, zaostrzanie prawa hazardowego) zamiast dążenia do zwiększenia bezpieczeństwa korzystania z hazardu (kontrola wieku, sprawdzanie tendencji do uzależniania się poszczególnych osób i personalizowanego im blokowania dostępu).",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Transmitowanie na żywo relacji ze spraw sądowych przynosi więcej szkód niż korzyści (np. sprawa Katarzyny W., proces sądowy Depp vs. Heard).",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "W Polsce należy wprowadzić możliwość głosowania negatywnego.",
+    "adinfo": "Na potrzeby debaty głosowanie negatywne to sposób głosowania w wyborach, polegający na odjęciu głosu od partii/osoby kandydującej. Liczy się on tak samo jak zwykły głos i wyklucza głosowanie „za” jakąkolwiek inną partią lub osobą kandydująca.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Państwo powinno zapewniać osobom potrzebującym pomoc bezwarunkową zamiast pomocy warunkowej (np. przyznawanie zasiłków pod warunkiem aktywnego poszukiwania pracy, oferowanie noclegów wyłącznie trzeźwym osobom).",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "W Polsce należy wprowadzić  „natychmiastową demokrację” sprawowaną przez obywateli za pomocą technologii X.",
+    "adinfo": "Na potrzeby debaty przyjmij, że istnieje technologia X. Polega ona na tym, że każdy obywatel w chwili uzyskania czynnego prawa wyborczego otrzymuje małe urządzenie, które pozwala mu co miesiąc oddać głos na którąś z partii politycznych. Comiesięczne głosowanie wpływa na skład parlamentu, w taki sposób, że w przypadku kiedy to partia miałaby stracić lub zyskać mandat w parlamencie, sama decyduje o osobie, której ten mandat przyznaje. Urządzenie głosujące jest zabezpieczone biometrycznie, w taki sposób, że nikt inny poza danym obywatelem nie jest w stanie go użyć. Urządzenia nie da się zhackować.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Państwo powinno stosować gwarancję zatrudnienia zamiast form walki z bezrobociem polegających na pomocy pośredniej (np. zapewnianiu szkoleń aktywizujących, zasiłków dla bezrobotnych).",
+    "adinfo": "Na potrzeby debaty gwarancja zatrudnienia stanowi program, w ramach którego rząd zobowiązuje się do stworzenia miejsca pracy dla każdego bezrobotnego, który zgłosi taką potrzebę. Oferowane w jej ramach wynagrodzenie powinno być zbliżone do płacy minimalnej.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Należy popierać nulifikację wyroku przez ławę przysięgłych",
+    "adinfo": "Nulifikacja wyroku przez ławę przysięgłych (tzw. „jury nullification”) występuje w systemie prawa precedensowego, kiedy to członkowie ławy przysięgłych w trakcie procesu karnego uważają, że oskarżony jest winny, ale decydują się przedstawić werdykt w tej sprawie jako uznanie za niewinnego, ponieważ: (a) uważają, że prawo na podstawie, którego oskarżony/a byłby/aby skazany/a jest niesprawiedliwe samo w sobie (b) oskarżyciel nadużył swoich uprawnień lub złamał prawo w sprawie oskarżonego/ej (c) potencjalna kara jest zbyt surowa.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "W Polsce należy wprowadzić kadencyjność posłów",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Państwo powinno wprowadzać kontrolę czynszów w centrach dużych miast",
+    "adinfo": "Kontrola czynszu to regulacje, które nakładają ograniczenia na kwotę, której właściciele mogą zażądać za wynajem mieszkania lub przedłużenie umowy najmu.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "System, w którym wszyscy oskarżeni w sprawach karnych byliby reprezentowani wyłącznie przez obrońców z urzędu przyniósłby więcej szkód niż korzyści",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Finał"
+  },
+  {
+    "lang": "pl",
+    "motion": "Popularyzacja memów politycznych przyniosła więcej szkód niż korzyści",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Półfinał"
+  },
+  {
+    "lang": "pl",
+    "motion": "",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Polska powinna wprowadzić instytucję sędziów pokoju.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "W krajach, w których obowiązuje powszechna służba wojskowa powinna dotyczyć ona również kobiet.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Instytucja małżeństwa przynosi więcej strat niż korzyści.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Gentryfikacja to proces przekształcenia danego obszaru miasta (np. dzielnicy) w obszar przeznaczony dla osób o wyższym statusie materialnym w celu osiągnięcia określonego celu finansowego czy wizerunkowego.",
+    "adinfo": "Proces gentryfikacji przynosi więcej strat niż korzyści.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Należy popierać wykluczenie państw posiadających niski wskaźnik przestrzegania praw człowieka z międzynarodowych wydarzeń sportowych.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Więźniowie powinni być zwalniani w oparciu o status ich resocjalizacji, zamiast po odbyciu wcześniej ustalonej kary.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Komercjalizacja ruchów społecznych przynosi więcej strat niż korzyści.",
+    "adinfo": "Komercjalizacja ruchów społecznych to m.in. wykorzystanie wizerunku celebrytów, ikon popkultury do popularyzacji danego ruchu społecznego jak i wykorzystywanie finansowania oraz pomocy organizacyjnej od korporacji i dużych przedsiębiorstw.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Zakładając istnienie umożliwiającej to technologii, funkcje sędziowskie w procesach sądowych powinno zastąpić się algorytmami.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Runda finałowa"
+  },
+  {
+    "lang": "pl",
+    "motion": "Należy żałować wzrostu popularności osób wykonujących zawody zaufania społecznego (np. lekarzy) w mediach społecznościowych.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Runda finałowa"
+  },
+  {
+    "lang": "pl",
+    "motion": "Jako rodzic pochodzący ze zmarginalizowanej grupy społecznej, uczyłbym swoje dzieci, aby nie ufały wymiarowi sprawiedliwości ani organom ścigania (tj. policji, sędziom, prokuratorom).",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Runda finałowa"
+  },
+  {
+    "lang": "pl",
+    "motion": "Państwowe subwencje partii politycznych przynoszą więcej strat niż korzyści.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Debata o trzecie miejsce"
+  },
+  {
+    "lang": "pl",
+    "motion": "Państwa młodych demokracji powinny priorytetyzować formę demokracji bezpośredniej ponad formę demokracji przedstawicielskiej..",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Finał"
+  },
+  {
+    "lang": "pl",
+    "motion": "Polska powinna wprowadzić regulacje nastawione na zwiększenie liczby kategorii recyklingu odpadów oraz na wysokie kary za nieprzestrzeganie nowych wytycznych.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Półfinał"
+  },
+  {
+    "lang": "pl",
+    "motion": "W interesie Polski leży działanie na rzecz dołączenia Ukrainy do Unii Europejskiej.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Istnienie „zasady trwałości stosunku pracy” należy ocenić pozytywnie.",
+    "adinfo": "„Zasada trwałości stosunku pracy” ogranicza możliwości zwolnienia pracownika przez pracodawcę. Celem jest zniechęcenie do wypowiedzenia istniejącej umowy z pracownikiem, nie zważając np. na to czy pracodawca zatrudnia inną osobę mogącą go zastąpić czy nie. Przykłady to zwiększone odprawy czy szczegółowe wymogi dotyczące przyczyn rozwiązania umowy. Zasada ta nie stanowi ochrony przed ewentualnym dyskryminującym wypowiedzeniem i nie ma charakteru bezwzględnego. Jest to konsekwencją obowiązywania zasady swobody pracy, która oznacza nie tylko swobodę wybrania pracy i nawiązania stosunku pracy, ale również możliwość jego rozwiązania przez każdą ze stron.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Występowanie technokracji na szczeblach samorządowych należy ocenić pozytywnie.",
+    "adinfo": "Technokracja – koncepcja ustroju społecznego, w którym władzę sprawowali by technicy, eksperci, organizatorzy i kierownicy produkcji.",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Politykę „grubej kreski” zastosowanej w Polsce po 1989 należy ocenić negatywnie.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "Lepszy jest system państwa federalnego od systemu państwa unitarnego.",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
+    "motion": "",
+    "adinfo": "",
+    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
+  },
+  {
+    "lang": "pl",
     "motion": "Robert Makłowicz byłby lepszym prezydentem RP niż Magda Gessler.",
     "adinfo": "",
     "source": "Poznańska Noc Debaty 2023, Faza grupowa"

--- a/src/data/motion.json
+++ b/src/data/motion.json
@@ -235,24 +235,6 @@
   },
   {
     "lang": "pl",
-    "motion": "",
-    "adinfo": "",
-    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
-  },
-  {
-    "lang": "pl",
-    "motion": "",
-    "adinfo": "",
-    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
-  },
-  {
-    "lang": "pl",
-    "motion": "",
-    "adinfo": "",
-    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2021, Eliminacje"
-  },
-  {
-    "lang": "pl",
     "motion": "Robert Makłowicz byłby lepszym prezydentem RP niż Magda Gessler.",
     "adinfo": "",
     "source": "Poznańska Noc Debaty 2023, Faza grupowa"

--- a/src/data/motion.json
+++ b/src/data/motion.json
@@ -79,12 +79,6 @@
   },
   {
     "lang": "pl",
-    "motion": "",
-    "adinfo": "",
-    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
-  },
-  {
-    "lang": "pl",
     "motion": "Państwo powinno stosować gwarancję zatrudnienia zamiast form walki z bezrobociem polegających na pomocy pośredniej (np. zapewnianiu szkoleń aktywizujących, zasiłków dla bezrobotnych).",
     "adinfo": "Na potrzeby debaty gwarancja zatrudnienia stanowi program, w ramach którego rząd zobowiązuje się do stworzenia miejsca pracy dla każdego bezrobotnego, który zgłosi taką potrzebę. Oferowane w jej ramach wynagrodzenie powinno być zbliżone do płacy minimalnej.",
     "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Eliminacje"
@@ -118,12 +112,6 @@
     "motion": "Popularyzacja memów politycznych przyniosła więcej szkód niż korzyści",
     "adinfo": "",
     "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2023, Półfinał"
-  },
-  {
-    "lang": "pl",
-    "motion": "",
-    "adinfo": "",
-    "source": "Turniej Debat Oksfordzkich o Tematyce Społeczno-Prawnej 2022, Eliminacje"
   },
   {
     "lang": "pl",


### PR DESCRIPTION
- The motions are sourced from the Court Watch Foundation [website](https://courtwatch.pl/)
- The PR includes motions from the years 2021-2023. I did not include all of the motions, as some delve into legal topics and terminology. While some aspects of the law frequently come up in Oxford debates, not every debater is a wannabe attorney