### PR TITLE
pass generated motion to config

### DIFF
--- a/src/components/MotionGenerator.tsx
+++ b/src/components/MotionGenerator.tsx
@@ -1,19 +1,26 @@
 "use client";
 import { motion } from "@/types/motion";
 import motions from "@/data/motion.json";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { IconInfo } from "@/components/icons/info";
 import { useLang } from "@/lib/useLang";
 import { GenericButton } from "./GenericButton";
-import { IconRotateCCW } from "./icons/RotateCCW";
+import { LinkButton } from "./LinkButton";
+import { DebateContext } from "@/contexts/DebateContext";
+import { IconDice } from "./icons/Dice";
+import { IconClock } from "./icons/Clock";
 
 const MotionGenerator = () => {
   const [motion, setMotion] = useState<motion | null>(null);
   const infoslideString = useLang("infoslide");
+  const debateSetupPath = "/../oxford-debate/setup";
+  const debateContext = useContext(DebateContext);
 
   function generateMotion(): motion {
     // TODO: add option to only generate motions in a chosen language
-    return motions[Math.floor(Math.random() * motions.length)];
+    const randomMotion = motions[Math.floor(Math.random() * motions.length)];
+    debateContext.setConf({ ...debateContext.conf, motion: randomMotion.motion || "" });
+    return randomMotion;
   }
 
   useEffect(() => {
@@ -22,11 +29,16 @@ const MotionGenerator = () => {
 
   return (
     <div className="flex flex-col items-center text-center">
-      <section className="max-w-[350px]">
+      <section className="flex flex-col space-y-2 max-w-[400px]">
         <GenericButton
           text={useLang("debateMotionGeneratorRegenerate")}
           icon={IconDice}
           onClick={() => setMotion(generateMotion())}
+        />
+        <LinkButton
+          text={useLang("debateOverThisMotion")}
+          icon={IconClock}
+          href={debateSetupPath}
         />
       </section>
       <section className="p-5">

--- a/src/components/MotionGenerator.tsx
+++ b/src/components/MotionGenerator.tsx
@@ -5,22 +5,27 @@ import { useContext, useEffect, useState } from "react";
 import { IconInfo } from "@/components/icons/info";
 import { useLang } from "@/lib/useLang";
 import { GenericButton } from "./GenericButton";
-import { LinkButton } from "./LinkButton";
 import { DebateContext } from "@/contexts/DebateContext";
 import { IconDice } from "./icons/Dice";
 import { IconClock } from "./icons/Clock";
+import { useRouter } from "next/navigation";
 
 const MotionGenerator = () => {
   const [motion, setMotion] = useState<motion | null>(null);
   const infoslideString = useLang("infoslide");
-  const debateSetupPath = "/../oxford-debate/setup";
   const debateContext = useContext(DebateContext);
+  const router = useRouter();
 
   function generateMotion(): motion {
     // TODO: add option to only generate motions in a chosen language
-    const randomMotion = motions[Math.floor(Math.random() * motions.length)];
-    debateContext.setConf({ ...debateContext.conf, motion: randomMotion.motion || "" });
-    return randomMotion;
+    return motions[Math.floor(Math.random() * motions.length)];
+  }
+
+  function saveMotionToContext(): void {
+    debateContext.setConf({
+      ...debateContext.conf,
+      motion: motion?.motion || "",
+    });
   }
 
   useEffect(() => {
@@ -35,10 +40,13 @@ const MotionGenerator = () => {
           icon={IconDice}
           onClick={() => setMotion(generateMotion())}
         />
-        <LinkButton
+        <GenericButton
           text={useLang("debateOverThisMotion")}
           icon={IconClock}
-          href={debateSetupPath}
+          onClick={() => {
+            saveMotionToContext();
+            router.push("/oxford-debate/setup");
+          }}
         />
       </section>
       <section className="p-5">

--- a/src/components/MotionGenerator.tsx
+++ b/src/components/MotionGenerator.tsx
@@ -25,7 +25,7 @@ const MotionGenerator = () => {
       <section className="max-w-[350px]">
         <GenericButton
           text={useLang("debateMotionGeneratorRegenerate")}
-          icon={IconRotateCCW}
+          icon={IconDice}
           onClick={() => setMotion(generateMotion())}
         />
       </section>

--- a/src/components/icons/Dice.tsx
+++ b/src/components/icons/Dice.tsx
@@ -9,10 +9,10 @@ const IconDice = (props: iconprops) => {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      className={`${props.moreClass}`}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={props.moreClass}
     >
       <rect width="12" height="12" x="2" y="10" rx="2" ry="2" />
       <path d="m17.92 14 3.5-3.5a2.24 2.24 0 0 0 0-3l-5-4.92a2.24 2.24 0 0 0-3 0L10 6" />

--- a/src/components/icons/Dice.tsx
+++ b/src/components/icons/Dice.tsx
@@ -1,0 +1,27 @@
+import { iconprops } from "@/types/iconprops";
+
+const IconDice = (props: iconprops) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className={`${props.moreClass}`}
+    >
+      <rect width="12" height="12" x="2" y="10" rx="2" ry="2" />
+      <path d="m17.92 14 3.5-3.5a2.24 2.24 0 0 0 0-3l-5-4.92a2.24 2.24 0 0 0-3 0L10 6" />
+      <path d="M6 18h.01" />
+      <path d="M10 14h.01" />
+      <path d="M15 6h.01" />
+      <path d="M18 9h.01" />
+    </svg>
+  );
+};
+
+export { IconDice };

--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -152,6 +152,11 @@
     "pl": "Wygeneruj tezę jeszcze raz",
     "de": "Die These nochmal generieren"
   },
+  "debateOverThisMotion": {
+    "en": "Debate over this motion",
+    "pl": "Debatuj nad tą tezą",
+    "de": "Darüber debattieren"
+  },
   "infoslide": {
     "en": "Infoslide",
     "pl": "Infoslajd"

--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -145,7 +145,8 @@
   },
   "debateMotionGeneratorFlavortext": {
     "en": "Motions taken from tournaments past.",
-    "pl": "Tezy "
+    "pl": "Tezy zaczerpnięte z minionych turniejów.",
+    "de": "Thesen aus vergangenen Wettbewerben entnommen."
   },
   "debateMotionGeneratorRegenerate": {
     "en": "Regenerate motion",


### PR DESCRIPTION
- The off-looking "repeat" icon is replaced with a new dice icon
- "Debate over this motion" button is added. I'm not 100% sure about its icon though. I would've probably used the "play circle" one but it is used to _start_ the debate, not enter its configuration. That's why I used the "clock" icon to be consistent with the main menu