### PR TITLE
Musketeers of Words 2024 motions

### DIFF
--- a/src/data/motion.json
+++ b/src/data/motion.json
@@ -1583,7 +1583,7 @@
   {
     "lang": "pl",
     "adinfo": "",
-    "motion": "Sportowiec, który został skazany za stosowanie srodków dopingujących, powinien miec permamentny zakaz uczestniczenia w zawodowych rozgrywkach sportowych.",
+    "motion": "Sportowiec, który został skazany za stosowanie środków dopingujących, powinien miec permanentny zakaz uczestniczenia w zawodowych rozgrywkach sportowych.",
     "source": "Kujawsko-Pomorska Liga Debat, Toruń, styczeń 2021",
     "type": "motionPlDuty"
   },
@@ -1638,8 +1638,8 @@
   },
   {
     "lang": "en",
-    "adinfo": "The fight against Climate Change should include taking international action against sovereign countries (such as exclusion from international institutions, sanctions, ect. or in the worst-case scenario - military intervention after seeking international approval), which allow environmental abuses thrugh direct action or political negligence",
-    "motion": "",
+    "adinfo": "",
+    "motion": "The fight against Climate Change should include taking international action against sovereign countries (such as exclusion from international institutions, sanctions, etc. or in the worst-case scenario - military intervention after seeking international approval), which allow environmental abuses through direct action or political negligence.",
     "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Group phase",
     "type": "motionEnDuty"
   },
@@ -1674,14 +1674,14 @@
   {
     "lang": "en",
     "adinfo": "For this debate assume you have an opportunity to take a pill that irreversibly changes your life. After taking it, you will not be lied to again. Once you learn (hear in conversation, read, etc.) new information, there will be an automatic confirmation of truth or warning in your brain that it is a lie. The \"technical\" side of the pill working will not annoy you nor hinder your daily functioning, it will keep working until you die. You are certain there are no health side effects. At the time of the decision you must be 18 years old, and once the choice is made it is final.",
-    "motion": "We decide to take a pill",
+    "motion": "We decide to take a pill.",
     "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Runners-up",
     "type": "motionEnFirstPerson"
   },
   {
     "lang": "en",
     "adinfo": "Info 1: For the purpose of this debate assume that the one ring is an embodiment of a universal dilemma \"The end justifies the means\". The one ring. Pope Francis won’t become Sauron’s puppet in a literal sense but there will be some corruption.\nInfo 2: As a pope of the Catholic church you see that it is in a deep crisis. Crisis of belief is becoming a solemn problem, requiring immediate action.",
-    "motion": "As a catholic pope Francis, I would wear the one-ring",
+    "motion": "As a catholic pope Francis, I would wear the one-ring.",
     "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Final",
     "type": "motionEnFirstPerson"
   }

--- a/src/data/motion.json
+++ b/src/data/motion.json
@@ -1635,5 +1635,54 @@
     "motion": "Włączenie się w realizację powojennej odbudowy kraju było dla polskich patriotów właściwszym wyborem niż walka zbrojna.",
     "source": "Debata pokazowa, Ostrołęka, marzec 2023",
     "type": "motionPlComparative"
+  },
+  {
+    "lang": "en",
+    "adinfo": "The fight against Climate Change should include taking international action against sovereign countries (such as exclusion from international institutions, sanctions, ect. or in the worst-case scenario - military intervention after seeking international approval), which allow environmental abuses thrugh direct action or political negligence",
+    "motion": "",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Group phase",
+    "type": "motionEnDuty"
+  },
+  {
+    "lang": "en",
+    "adinfo": "Post-Soviet countries refer to the independent nations that emerged following the dissolution of the Soviet Union in 1991. UE post-soviet countries are Poland, Hungary, Czech Republic, Slovakia, Estonia, Latvia, and Lithuania. As a parent from these countries, you've seen rock bottom, work struggle and education chasing. For the first time in your life, you can describe yourself as a successful person in a good financial situation.",
+    "motion": "As a parent in 2015-2024 in the UE post soviet countries I would raise my child using \"a tiger parent\" method.",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Group phase",
+    "type": "motionEnFirstPerson"
+  },
+  {
+    "lang": "en",
+    "adinfo": "For the purpose of this debate there are 3 main passions - love, poser, and fame. We assume they can be pursued at the same time, however they differ from each other.",
+    "motion": "Love is the most selfish of all passions.",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Group phase",
+    "type": "motionEnComparative"
+  },
+  {
+    "lang": "en",
+    "adinfo": "In the middle of the Baltic Sea, an island with a population has appeared. The new state of \"Balticstan\" is seeking the best political system to govern itself. The country has guaranteed independence and is sovereign over regional powers at the time of the debate. Balticstan represents the maximum average of all countries bordering the Baltic Sea (nine countries in total) regarding population, economy, problems and opportunities.",
+    "motion": "As a society of a newly established state, we would opt for a representative democracy system.",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Quarterfinal",
+    "type": "motionEnFirstPerson"
+  },
+  {
+    "lang": "en",
+    "adinfo": "For the purpose of this debate both assume betrayal is strictly understood in the sphere of personal human relationships. We exclude business and professional relations.",
+    "motion": "The world/life in which betrayal is normalized would be better.",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Semifinal",
+    "type": "motionEnComparative"
+  },
+  {
+    "lang": "en",
+    "adinfo": "For this debate assume you have an opportunity to take a pill that irreversibly changes your life. After taking it, you will not be lied to again. Once you learn (hear in conversation, read, etc.) new information, there will be an automatic confirmation of truth or warning in your brain that it is a lie. The \"technical\" side of the pill working will not annoy you nor hinder your daily functioning, it will keep working until you die. You are certain there are no health side effects. At the time of the decision you must be 18 years old, and once the choice is made it is final.",
+    "motion": "We decide to take a pill",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Runners-up",
+    "type": "motionEnFirstPerson"
+  },
+  {
+    "lang": "en",
+    "adinfo": "Info 1: For the purpose of this debate assume that the one ring is an embodiment of a universal dilemma \"The end justifies the means\". The one ring. Pope Francis won’t become Sauron’s puppet in a literal sense but there will be some corruption.\nInfo 2: As a pope of the Catholic church you see that it is in a deep crisis. Crisis of belief is becoming a solemn problem, requiring immediate action.",
+    "motion": "As a catholic pope Francis, I would wear the one-ring",
+    "source": "Musketeers of Words - Polish Oxford Debates Championships in English 2024, Final",
+    "type": "motionEnFirstPerson"
   }
 ]

--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -274,6 +274,12 @@
   "motionEnPolicy": {
     "en": "Motion of policy"
   },
+  "motionEnDuty": {
+    "en": "Motion of duty"
+  },
+  "motionEnComparative": {
+    "en": "Comparative motion"
+  },
   "brandingdisplayimage": {
     "en": "Clock branding image",
     "pl": "Logotyp zegarowy"


### PR DESCRIPTION
The phrasing of MoW 2024 motions is somewhat erroneous. What bugs me the most is the inconsistency in Oxford comma usage. I was tempted to edit at least that. As for now, the motions in the file are according to the original.

[Group phase](https://www.facebook.com/muszkieterowie.slowa/posts/pfbid02i5rY5PkbEpvtAc1t5Pj5UFL3zhdPY4Tsit8oTtjGoRuoGgcxEyUabHSXSWeMUk5ql)
[Final phase](https://www.facebook.com/muszkieterowie.slowa/posts/pfbid0Vp8hoq3WV1xdM4vTAAeKFNDsMrXRquesNkTLHMWvTqQA3PPLPAVc6R2HLdefoHz6l)