### PR TITLE
Restore default debate setup

### DIFF
--- a/src/types/debate.ts
+++ b/src/types/debate.ts
@@ -22,13 +22,13 @@ const defaultDebateConf: debateConf = {
   motion: "",
   proTeam: "",
   oppTeam: "",
-  speechTime: 300,
+  speechTime: 240,
   adVocemTime: 60,
   endProtectedTime: 30,
-  startProtectedTime: 30,
+  startProtectedTime: 0,
   beepOnSpeechEnd: true,
   beepProtectedTime: true,
   visualizeProtectedTimes: false,
-  displayImage1: "MOW2024",
+  displayImage1: "null",
 };
 export { defaultDebateConf };


### PR DESCRIPTION
This PR undoes changes made in [ce095de](https://github.com/jakubmanczak/debates/commit/ce095de9c53ee0bf10db7048510ffb564ed2936c), as Musketeers of Words tournament is over.